### PR TITLE
[fix] Upgrade to MLflow 3.9.0rc0 and databricks-agents 1.9.3            

### DIFF
--- a/notebooks/05_deploy_agent/deploy_agent.py
+++ b/notebooks/05_deploy_agent/deploy_agent.py
@@ -157,7 +157,6 @@ try:
         wait_for_ready=config.wait_for_ready,
         permissions=config.permissions,
         instructions=config.instructions,
-        budget_policy_id=None,
     )
 
     print("Deployment completed successfully!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "six==1.16.0",
     "unitycatalog-ai[databricks]>=0.3.2,<0.4",
     "unitycatalog-openai[Databricks]>=0.2.0,<0.3",
-    "databricks-agents>=1.8.2,<2",
+    "databricks-agents==1.9.3",
     "databricks-vectorsearch>=0.62.0,<0.63",
     "databricks-openai==0.6.1",
     "databricks-mcp==0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "pydantic>=2.10.0,<3",
     "faker>=20.1.0,<21",
     "databricks-sdk==0.73.0",
-    "mlflow[databricks]>=3.6.0",
+    "mlflow[databricks]==3.9.0rc0",
     "openai>=2.7.2,<3",
     "backoff>=2.2.1,<3",
     "six==1.16.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 pydantic>=2.10.0,<3
 faker>=20.1.0,<21
 databricks-sdk==0.73.0
-mlflow[databricks]>=3.6.0
+mlflow[databricks]==3.9.0rc0
 openai>=2.7.2,<3
 backoff>=2.2.1,<3
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ backoff>=2.2.1,<3
 six==1.16.0
 unitycatalog-ai[databricks]>=0.3.2,<0.4
 unitycatalog-openai[Databricks]>=0.2.0,<0.3
-databricks-agents>=1.8.2,<2
+databricks-agents==1.9.3
 databricks-vectorsearch>=0.62.0,<0.63
 databricks-openai==0.6.1
 databricks-mcp==0.4.0

--- a/telco_support_agent/ops/deployment.py
+++ b/telco_support_agent/ops/deployment.py
@@ -79,15 +79,19 @@ def deploy_agent(
         # deploy agent
         logger.info("Starting deployment...")
 
-        deployment = agents.deploy(
-            model_name=uc_model_name,
-            model_version=model_version,
-            endpoint_name=deployment_name,
-            scale_to_zero=scale_to_zero_enabled,
-            environment_vars=environment_vars,
-            workload_size=workload_size,
-            budget_policy_id=budget_policy_id,
-        )
+        deploy_kwargs = {
+            "model_name": uc_model_name,
+            "model_version": model_version,
+            "endpoint_name": deployment_name,
+            "scale_to_zero": scale_to_zero_enabled,
+            "environment_vars": environment_vars,
+            "workload_size": workload_size,
+        }
+        # Only include budget_policy_id if explicitly set
+        if budget_policy_id is not None:
+            deploy_kwargs["budget_policy_id"] = budget_policy_id
+
+        deployment = agents.deploy(**deploy_kwargs)
 
         logger.info(
             f"Agent deployment started. Endpoint name: {deployment.endpoint_name}"

--- a/telco_support_agent/ops/deployment.py
+++ b/telco_support_agent/ops/deployment.py
@@ -47,7 +47,6 @@ def deploy_agent(
         wait_for_ready: Whether to wait for deployment to be ready
         permissions: Optional permissions configuration dict with 'users' and 'permission_level'
         instructions: Optional review instructions for the Review App
-        budget_policy_id: Optional budget policy ID
 
     Returns:
         Deployment object with information about the deployed agent
@@ -86,7 +85,7 @@ def deploy_agent(
             "environment_vars": environment_vars,
             "workload_size": workload_size,
         }
-        
+
         deployment = agents.deploy(**deploy_kwargs)
 
         logger.info(

--- a/telco_support_agent/ops/deployment.py
+++ b/telco_support_agent/ops/deployment.py
@@ -33,7 +33,6 @@ def deploy_agent(
     wait_for_ready: bool = True,
     permissions: Optional[dict] = None,
     instructions: Optional[str] = None,
-    budget_policy_id: Optional[str] = None,
 ) -> Any:
     """Deploy a registered agent model to a Model Serving endpoint.
 
@@ -87,10 +86,7 @@ def deploy_agent(
             "environment_vars": environment_vars,
             "workload_size": workload_size,
         }
-        # Only include budget_policy_id if explicitly set
-        if budget_policy_id is not None:
-            deploy_kwargs["budget_policy_id"] = budget_policy_id
-
+        
         deployment = agents.deploy(**deploy_kwargs)
 
         logger.info(

--- a/telco_support_agent/ui/requirements.txt
+++ b/telco_support_agent/ui/requirements.txt
@@ -16,7 +16,7 @@ structlog==23.2.0
 databricks-sdk
 
 # MLflow
-mlflow
+mlflow==3.9.0rc0
 
 # dbdemos tracking
 dbdemos_tracker

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -1565,7 +1568,7 @@ wheels = [
 
 [[package]]
 name = "mlflow"
-version = "3.6.0"
+version = "3.9.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -1584,12 +1587,13 @@ dependencies = [
     { name = "pyarrow" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "skops" },
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/25/930b5312952b2645f066ffacca5bee8e36577c35e327545da225440cbb6a/mlflow-3.6.0.tar.gz", hash = "sha256:d945d259b5c6b551a9f26846db8979fd84c78114a027b77ada3298f821a9b0e1", size = 8371484, upload-time = "2025-11-07T19:00:30.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/26/aa1f169bb3211a3595a845e2e74b7b49068bc494a4f0d757a492eab9f511/mlflow-3.9.0rc0.tar.gz", hash = "sha256:17116e34d004c0670867701d3082aae685bb754332a9daa2c1a4352d96b81df5", size = 8951527, upload-time = "2026-01-16T03:31:26.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/69/5b018518b2fbd02481b58f7ca14f4a489b51e3c2d95cdc1b973135e8d456/mlflow-3.6.0-py3-none-any.whl", hash = "sha256:04d1691facd412be8e61b963fad859286cfeb2dbcafaea294e6aa0b83a15fc04", size = 8860293, upload-time = "2025-11-07T19:00:27.555Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5b/35105ec4af551f1ca22aa1dcf4e915444d3b7bd52dc27548e6bda70bb405/mlflow-3.9.0rc0-py3-none-any.whl", hash = "sha256:2591f913dca2a745727c8ce8e232641ab187fa2305ade9236c497d4b3f80cdd2", size = 9504703, upload-time = "2026-01-16T03:31:24.424Z" },
 ]
 
 [package.optional-dependencies]
@@ -1603,7 +1607,7 @@ databricks = [
 
 [[package]]
 name = "mlflow-skinny"
-version = "3.6.0"
+version = "3.9.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1626,14 +1630,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/8e/2a2d0cd5b1b985c5278202805f48aae6f2adc3ddc0fce3385ec50e07e258/mlflow_skinny-3.6.0.tar.gz", hash = "sha256:cc04706b5b6faace9faf95302a6e04119485e1bfe98ddc9b85b81984e80944b6", size = 1963286, upload-time = "2025-11-07T18:33:52.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/dd/d0c3a0e7462b56d63a40b272040bbb4ee6124e17237df083266117a9d201/mlflow_skinny-3.9.0rc0.tar.gz", hash = "sha256:69cacf234bef0989e4fbd63b05ef8b641e5ca7a541825f70f61add9dac0fb003", size = 2208610, upload-time = "2026-01-16T03:16:11.652Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/78/e8fdc3e1708bdfd1eba64f41ce96b461cae1b505aa08b69352ac99b4caa4/mlflow_skinny-3.6.0-py3-none-any.whl", hash = "sha256:c83b34fce592acb2cc6bddcb507587a6d9ef3f590d9e7a8658c85e0980596d78", size = 2364629, upload-time = "2025-11-07T18:33:50.744Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/22/fc86db2a0d9be47f09bc84143818ceb33f62bebd77a32f499b9470059472/mlflow_skinny-3.9.0rc0-py3-none-any.whl", hash = "sha256:19fc2c529d318ff2fe53305d03ef022e8bc39bf4766035b96f3f1885287a8c9b", size = 2658855, upload-time = "2026-01-16T03:16:09.345Z" },
 ]
 
 [[package]]
 name = "mlflow-tracing"
-version = "3.6.0"
+version = "3.9.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1645,9 +1649,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/4e/a1b2f977a50ed3860e2848548a9173b9018806628d46d5bdafa8b45bc0c7/mlflow_tracing-3.6.0.tar.gz", hash = "sha256:ccff80b3aad6caa18233c98ba69922a91a6f914e0a13d12e1977af7523523d4c", size = 1061879, upload-time = "2025-11-07T18:36:24.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/04/e207631631974fa12bbcd19453ce5eafb5e0db536c3180f5e71d411d08f2/mlflow_tracing-3.9.0rc0.tar.gz", hash = "sha256:0c47af012fca61b5f3d9beb5b267ecfbb011dd3666e10ab6bfc777d2cf2b8b15", size = 1167782, upload-time = "2026-01-16T03:18:31.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/ec/ba3f513152cf5404e36263604d484728d47e61678c39228c36eb769199af/mlflow_tracing-3.6.0-py3-none-any.whl", hash = "sha256:a68ff03ba5129c67dc98e6871e0d5ef512dd3ee66d01e1c1a0c946c08a6d4755", size = 1281617, upload-time = "2025-11-07T18:36:23.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4a/d6b47f19561205472abf0e221a47e4c2b80d9d6a0a7a86b46c654007953b/mlflow_tracing-3.9.0rc0-py3-none-any.whl", hash = "sha256:5a8314e80aaad5353eb6941d08c22fa304df419447e4b056fbe98370f7248443", size = 1400619, upload-time = "2026-01-16T03:18:29.921Z" },
 ]
 
 [[package]]
@@ -1962,6 +1966,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815, upload-time = "2024-07-28T19:59:01.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643, upload-time = "2024-07-28T19:58:59.335Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -2491,6 +2507,22 @@ wheels = [
 ]
 
 [[package]]
+name = "skops"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "prettytable" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/0c/5ec987633e077dd0076178ea6ade2d6e57780b34afea0b497fb507d7a1ed/skops-0.13.0.tar.gz", hash = "sha256:66949fd3c95cbb5c80270fbe40293c0fe1e46cb4a921860e42584dd9c20ebeb1", size = 581312, upload-time = "2025-08-06T09:48:14.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/e8/6a2b2030f0689f894432b9c2f0357f2f3286b2a00474827e04b8fe9eea13/skops-0.13.0-py3-none-any.whl", hash = "sha256:55e2cccb18c86f5916e4cfe5acf55ed7b0eecddf08a151906414c092fa5926dc", size = 131200, upload-time = "2025-08-06T09:48:13.356Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2624,7 +2656,7 @@ requires-dist = [
     { name = "databricks-sdk", specifier = "==0.73.0" },
     { name = "databricks-vectorsearch", specifier = ">=0.62.0,<0.63" },
     { name = "faker", specifier = ">=20.1.0,<21" },
-    { name = "mlflow", extras = ["databricks"], specifier = ">=3.6.0" },
+    { name = "mlflow", extras = ["databricks"], specifier = "==3.9.0rc0" },
     { name = "openai", specifier = ">=2.7.2,<3" },
     { name = "pydantic", specifier = ">=2.10.0,<3" },
     { name = "six", specifier = "==1.16.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -405,17 +405,19 @@ wheels = [
 
 [[package]]
 name = "databricks-agents"
-version = "1.8.2"
+version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
-    { name = "databricks-connect" },
     { name = "databricks-sdk", extra = ["openai"] },
     { name = "dataclasses-json" },
+    { name = "googleapis-common-protos" },
     { name = "jinja2" },
     { name = "litellm" },
     { name = "mlflow-skinny" },
+    { name = "numpy" },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "tenacity" },
     { name = "tiktoken" },
@@ -424,7 +426,7 @@ dependencies = [
     { name = "whenever" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/24/fc27ab4d378a3f94d4065de551202a8ef4660620e870ae086444c4a1e9a3/databricks_agents-1.8.2-py3-none-any.whl", hash = "sha256:4957833dcd71622475a6ac9291929fd795131fda3aaebd37c9af873cf1db02dc", size = 202415, upload-time = "2025-11-06T00:59:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/03/60/d57ad1221fb69ff1eaa11525936d82efa9dd39bb5f8e148bda27a6019c53/databricks_agents-1.9.3-py3-none-any.whl", hash = "sha256:5767607d40ea6fd8a11f15519b2ad01a66cfb961382dffb2bed13bdd1dd79d09", size = 203107, upload-time = "2026-01-27T19:56:50.747Z" },
 ]
 
 [[package]]
@@ -643,6 +645,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/d7/6c8b3bfe33eeffa208183ec037fee0cce9f7f024089ab1c5d12ef04bd27c/fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143", size = 296485, upload-time = "2025-07-11T16:22:32.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565", size = 95631, upload-time = "2025-07-11T16:22:30.485Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
 ]
 
 [[package]]
@@ -1444,11 +1465,12 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.75.9"
+version = "1.81.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
+    { name = "fastuuid" },
     { name = "httpx" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
@@ -1459,9 +1481,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/d8/08615bc4811d9a6df2b46f8efa7a0d6f7f8e1ca268a4c794540d9987a035/litellm-1.75.9.tar.gz", hash = "sha256:d8baf4b9988df599b55cb675808bbe22cedee2f099ba883684fe3f23af8d13a9", size = 10142656, upload-time = "2025-08-20T17:43:50.554Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/dd/d70835d5b231617761717cd5ba60342b677693093a71d5ce13ae9d254aee/litellm-1.81.3.tar.gz", hash = "sha256:a7688b429a88abfdd02f2a8c3158ebb5385689cfb7f9d4ac1473d018b2047e1b", size = 13612652, upload-time = "2026-01-25T02:45:58.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/b2/f21db9636d9fcd67b2c557c58aafb8a6e9b53864f7a40d645e09c2e3ab98/litellm-1.75.9-py3-none-any.whl", hash = "sha256:a72c3e05bcb0e50ac1804f0df09d0d7bf5cb41e84351e1609a960033b0ef01c1", size = 8920144, upload-time = "2025-08-20T17:43:48.327Z" },
+    { url = "https://files.pythonhosted.org/packages/83/62/d3f53c665261fdd5bb2401246e005a4ea8194ad1c4d8c663318ae3d638bf/litellm-1.81.3-py3-none-any.whl", hash = "sha256:3f60fd8b727587952ad3dd18b68f5fed538d6f43d15bb0356f4c3a11bccb2b92", size = 11946995, upload-time = "2026-01-25T02:45:55.887Z" },
 ]
 
 [[package]]
@@ -1746,7 +1768,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.7.2"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1758,9 +1780,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/e3/cec27fa28ef36c4ccea71e9e8c20be9b8539618732989a82027575aab9d4/openai-2.7.2.tar.gz", hash = "sha256:082ef61163074d8efad0035dd08934cf5e3afd37254f70fc9165dd6a8c67dcbd", size = 595732, upload-time = "2025-11-10T16:42:31.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/66/22cfe4b695b5fd042931b32c67d685e867bfd169ebf46036b95b57314c33/openai-2.7.2-py3-none-any.whl", hash = "sha256:116f522f4427f8a0a59b51655a356da85ce092f3ed6abeca65f03c8be6e073d9", size = 1008375, upload-time = "2025-11-10T16:42:28.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
 ]
 
 [[package]]
@@ -2650,7 +2672,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backoff", specifier = ">=2.2.1,<3" },
-    { name = "databricks-agents", specifier = ">=1.8.2,<2" },
+    { name = "databricks-agents", specifier = "==1.9.3" },
     { name = "databricks-mcp", specifier = "==0.4.0" },
     { name = "databricks-openai", specifier = "==0.6.1" },
     { name = "databricks-sdk", specifier = "==0.73.0" },


### PR DESCRIPTION
## What                                                             
Upgrade MLflow to 3.9.0rc0 and databricks-agents to 1.9.3, and remove budget policy handling from agent deployment.                
                                                                    
## Why                                                              
- MLflow 3.9.0rc0 contains latest agent features and fixes          
- databricks-agents 1.9.3 is required for compatibility with MLflow 
3.9.0rc0 (fixes path construction bug with `models:` URI)           
- Budget policy parameter was causing `PERMISSION_DENIED` errors due
 to workspace default policy enforcement                            
                                                                    
## Key Changes                                                      
- Bumped `mlflow[databricks]` from `>=3.6.0` to `==3.9.0rc0`        
- Bumped `databricks-agents` from `>=1.8.2,<2` to `==1.9.3`         
- Removed `budget_policy_id` parameter from `deploy_agent()`        
function signature                                                  
- Updated `agents.deploy()` call to not pass budget policy, avoiding
 workspace default policy issues                                    
- Regenerated `uv.lock` with `--prerelease=allow`                   
                                                                    
## Testing                                                          
- Verified lockfile resolves correctly with `uv lock                
--prerelease=allow`                                                 
- Deploy agent notebook tested on Databricks workspace